### PR TITLE
Moving CI to CI_ENV 

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -346,7 +346,7 @@ describe('Version Generator', () => {
           REPOSITORY_NAME: 'testrepo',
           SHA: 'abcdef1234567890',
           TOKEN: 'mock-token',
-          CI: 'true',
+          CI_ENV: 'true',
         }),
       );
     });
@@ -465,7 +465,7 @@ describe('getLatestTag with GitHub API', () => {
         REPOSITORY_OWNER: 'Wellsite-Navigator',
         REPOSITORY_NAME: 'wellsite-portal',
         TOKEN: 'mock-token',
-        CI: 'true',
+        CI_ENV: 'true',
       }),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,14 +40,14 @@ export const defaultExecutor: Executor = {
   mkdirSync: (dirPath: string, options?: { recursive: boolean }) => mkdirSync(dirPath, options),
   getGitHubData: async (url: string, env: EnvVars) => {
     // Fail if TOKEN is missing when running in CI
-    if (!env.TOKEN && env.CI === 'true') {
+    if (!env.TOKEN && env.CI_ENV === 'true') {
       throw new Error(
         'TOKEN environment variable is not set. This is required for GitHub API access when running in CI.',
       );
     }
 
     // Warn if TOKEN is missing but not in CI
-    if (!env.TOKEN && env.CI !== 'true') {
+    if (!env.TOKEN && env.CI_ENV !== 'true') {
       console.warn('Warning: TOKEN environment variable is not set. GitHub API requests may be rate-limited.');
     }
 
@@ -200,7 +200,7 @@ export async function getLatestTag({
   const resolvedExecutor = executor || defaultExecutor;
 
   // If running in CI, use the GitHub API
-  if (env.CI === 'true') {
+  if (env.CI_ENV === 'true') {
     try {
       return await getLatestTagFromGitHub(resolvedExecutor, env);
     } catch (error) {
@@ -259,7 +259,7 @@ export async function getCommitCount(
   const env = options.env;
 
   // No special case needed as we're failing when no tags are found
-  if (env.CI === 'true') {
+  if (env.CI_ENV === 'true') {
     try {
       return await getCommitCountFromGitHub(fromTag, executor, env);
     } catch (error: unknown) {

--- a/src/normalize-env.test.ts
+++ b/src/normalize-env.test.ts
@@ -20,7 +20,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME).toBe('repo');
       expect(normalized.SHA).toBe('abcdef1234567890');
       expect(normalized.BRANCH_NAME).toBe('main');
-      expect(normalized.CI).toBe('true');
+      expect(normalized.CI_ENV).toBe('true');
 
       // Check source tracking
       expect(normalized.TOKEN_SOURCE).toBe('GITHUB');
@@ -28,7 +28,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME_SOURCE).toBe('GITHUB');
       expect(normalized.SHA_SOURCE).toBe('GITHUB');
       expect(normalized.BRANCH_NAME_SOURCE).toBe('GITHUB');
-      expect(normalized.CI_SOURCE).toBe('GITHUB');
+      expect(normalized.CI_ENV_SOURCE).toBe('GITHUB');
     });
 
     it('should handle GitHub pull request environment variables', () => {
@@ -69,7 +69,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME).toBe('repo');
       expect(normalized.SHA).toBe('abcdef1234567890');
       expect(normalized.BRANCH_NAME).toBe('main');
-      expect(normalized.CI).toBe('true');
+      expect(normalized.CI_ENV).toBe('true');
 
       // Check source tracking
       expect(normalized.TOKEN_SOURCE).toBe('GITHUB');
@@ -77,7 +77,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME_SOURCE).toBe('VERCEL');
       expect(normalized.SHA_SOURCE).toBe('VERCEL');
       expect(normalized.BRANCH_NAME_SOURCE).toBe('VERCEL');
-      expect(normalized.CI_SOURCE).toBe('VERCEL');
+      expect(normalized.CI_ENV_SOURCE).toBe('VERCEL');
     });
   });
 
@@ -99,7 +99,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME).toBe('repo');
       expect(normalized.SHA).toBe('abcdef1234567890');
       expect(normalized.BRANCH_NAME).toBe('main');
-      expect(normalized.CI).toBe('true');
+      expect(normalized.CI_ENV).toBe('true');
 
       // Check source tracking
       expect(normalized.TOKEN_SOURCE).toBe('TRAVIS');
@@ -107,7 +107,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME_SOURCE).toBe('TRAVIS');
       expect(normalized.SHA_SOURCE).toBe('TRAVIS');
       expect(normalized.BRANCH_NAME_SOURCE).toBe('TRAVIS');
-      expect(normalized.CI_SOURCE).toBe('TRAVIS');
+      expect(normalized.CI_ENV_SOURCE).toBe('TRAVIS');
     });
 
     it('should handle Travis CI pull request', () => {
@@ -132,12 +132,12 @@ describe('normalizeEnvironment', () => {
   describe('Generic CI environment variables', () => {
     it('should handle generic CI environment', () => {
       const testEnv = {
-        CI: 'true',
+        CI_ENV: 'true',
       };
 
       const normalized = normalizeEnvironment(testEnv);
-      expect(normalized.CI).toBe('true');
-      expect(normalized.CI_SOURCE).toBe('ENV');
+      expect(normalized.CI_ENV).toBe('true');
+      expect(normalized.CI_ENV_SOURCE).toBe('ENV');
     });
   });
 
@@ -151,7 +151,7 @@ describe('normalizeEnvironment', () => {
       expect(normalized.REPOSITORY_NAME).toBeUndefined();
       expect(normalized.SHA).toBeUndefined();
       expect(normalized.BRANCH_NAME).toBeUndefined();
-      expect(normalized.CI).toBeUndefined();
+      expect(normalized.CI_ENV).toBeUndefined();
     });
   });
 
@@ -184,8 +184,8 @@ describe('normalizeEnvironment', () => {
       expect(normalized.BRANCH_NAME).toBe('main');
       expect(normalized.BRANCH_NAME_SOURCE).toBe('VERCEL');
 
-      expect(normalized.CI).toBe('true');
-      expect(normalized.CI_SOURCE).toBe('TRAVIS');
+      expect(normalized.CI_ENV).toBe('true');
+      expect(normalized.CI_ENV_SOURCE).toBe('TRAVIS');
     });
   });
 });

--- a/src/normalize-env.ts
+++ b/src/normalize-env.ts
@@ -10,7 +10,7 @@ export type EnvVars = {
   REPOSITORY_NAME?: string; // Just the repo name without owner
   SHA?: string;
   BRANCH_NAME?: string; // Single field for branch name (PR source branch or regular branch)
-  CI?: string;
+  CI_ENV?: string;
 
   // Source tracking for each normalized variable
   TOKEN_SOURCE?: string;
@@ -18,7 +18,7 @@ export type EnvVars = {
   REPOSITORY_NAME_SOURCE?: string;
   SHA_SOURCE?: string;
   BRANCH_NAME_SOURCE?: string;
-  CI_SOURCE?: string;
+  CI_ENV_SOURCE?: string;
 
   // Allow any other environment variables that might be passed through
   [key: string]: string | undefined;
@@ -127,9 +127,9 @@ export function normalizeEnvironment(env: Record<string, string | undefined>): E
     // Add other CI branch variables
   ]);
 
-  // CI (detect if running in CI)
+  // CI_ENV (detect if running in CI)
   normalizeVar(
-    'CI',
+    'CI_ENV',
     [
       ['GITHUB_ACTIONS', 'GITHUB'],
       ['VERCEL', 'VERCEL'],


### PR DESCRIPTION
Cercel sets CI to "1", but we normalize it to 'true'. to avoid conflict, setting our internal expected variable to be CI_ENV and setting to "true" when set.